### PR TITLE
The parent theme is now observatory-wp-theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Arctic Carbon Observatory theme for WordPress 
-Child theme of Field Carbon observatory https://github.com/hamk-uas/fieldobservatory-wp-theme
+# Arctic Carbon Observatory child theme for WordPress 
+Must be used together with Observatory parent theme https://github.com/hamk-uas/observatory-wp-theme.
 Visit Field Observatory at https://www.fieldobservatory.org.
 
 ## Authors:

--- a/assets/css/ACODataViewer.css
+++ b/assets/css/ACODataViewer.css
@@ -7,7 +7,7 @@
 }
 
 .chart_colorbar_container {
-    margin-left: 5px;
+    margin-left: 10px;
 }
 
 #afterMapDiv {

--- a/assets/css/ACODataViewer.css
+++ b/assets/css/ACODataViewer.css
@@ -5,3 +5,11 @@
 .fieldInfoDiv, .EditSite {
     display: none !important;
 }
+
+.chart_colorbar_container {
+    margin-left: 5px;
+}
+
+#afterMapDiv {
+    margin-top: 10px;
+}

--- a/assets/js/ACOConfig.js
+++ b/assets/js/ACOConfig.js
@@ -303,7 +303,8 @@ var childOConfig = {
                         "id": "tropomi_ch4_image",
                         "title": "tropomi daily methane",
                         "description": "Tropomi data.",
-                        "yLabel": "CH₄ (ppb)"
+                        "yLabel": "CH₄",
+                        "yUnit": "ppb"
                     }
                 ],
                 "sourceTypes": [

--- a/assets/js/ACOConfig.js
+++ b/assets/js/ACOConfig.js
@@ -303,6 +303,7 @@ var childOConfig = {
                         "id": "tropomi_ch4_image",
                         "title": "tropomi daily methane",
                         "description": "Tropomi data.",
+                        "yLabel": "CH₄ (ppb)"
                     }
                 ],
                 "sourceTypes": [
@@ -317,5 +318,6 @@ var childOConfig = {
     },
     colormaps: {
         'tropomi_ch4_image': getColormap(plasma.reverse(), 1600, 2000)
-    }
+    },
+    siteId: "global"
 }

--- a/functions.php
+++ b/functions.php
@@ -1,7 +1,6 @@
-<script id="fieldobservatory-markdown-it-js" src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/13.0.1/markdown-it.min.js" integrity="sha512-SYfDUYPg5xspsG6OOpXU366G8SZsdHOhqk/icdrYJ2E/WKZxPxze7d2HD3AyXpT7U22PZ5y74xRpqZ6A2bJ+kQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script> <!-- https://github.com/markdown-it/markdown-it -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.7.5/proj4.min.js" integrity="sha512-Nwp3XMQKRvqr376bCa50Hs4X4z5zbsefo63QLa62poTx5o/GhYgjnToCoBZk7bxjeP2y84oEgKNUrpK2+2Czyg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script> <!-- https://github.com/proj4js/proj4js -->
-<script type="text/javascript" id="fieldobservatory-FODataViewerCoreJs-js" src="<?php echo get_parent_theme_file_uri("/assets/js/FODataViewerCore.js")?>?ver=<?php echo wp_get_theme()->version ?>"></script>
 <?php 
 wp_enqueue_style('arcticcarbonobservatory-ACODataViewer',get_theme_file_uri("/assets/css/ACODataViewer.css"),array(),wp_get_theme()->version,'all');
+wp_enqueue_script('observatory-markdown-it-js','https://cdnjs.cloudflare.com/ajax/libs/markdown-it/13.0.1/markdown-it.min.js',array(),wp_get_theme()->version,true);
+wp_enqueue_script('observatory-proj4','https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.7.5/proj4.min.js',array(),wp_get_theme()->version,true);
+wp_enqueue_script('observatory-ODataViewerCoreJs-js',get_parent_theme_file_uri("/assets/js/ODataViewerCore.js"),array(),wp_get_theme()->version,true);
 wp_enqueue_script('arcticcarbonobservatory-ACOConfigJS',get_theme_file_uri("/assets/js/ACOConfig.js"),array(),wp_get_theme()->version,true);
-?> 

--- a/functions.php
+++ b/functions.php
@@ -1,5 +1,10 @@
 <?php 
-wp_enqueue_style('arcticcarbonobservatory-ACODataViewer',get_theme_file_uri("/assets/css/ACODataViewer.css"),array(),wp_get_theme()->version,'all');
+function arcticcarbonobservatory_register_styles() {
+    wp_enqueue_style('arcticcarbonobservatory-ACODataViewer',get_theme_file_uri("/assets/css/ACODataViewer.css"),array(),wp_get_theme()->version,'all');
+}
+
+add_action('wp_enqueue_scripts','arcticcarbonobservatory_register_styles', 11);
+
 wp_enqueue_script('observatory-markdown-it-js','https://cdnjs.cloudflare.com/ajax/libs/markdown-it/13.0.1/markdown-it.min.js',array(),wp_get_theme()->version,true);
 wp_enqueue_script('observatory-proj4','https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.7.5/proj4.min.js',array(),wp_get_theme()->version,true);
 wp_enqueue_script('observatory-ODataViewerCoreJs-js',get_parent_theme_file_uri("/assets/js/ODataViewerCore.js"),array(),wp_get_theme()->version,true);

--- a/style.css
+++ b/style.css
@@ -1,10 +1,10 @@
 /*
-Theme Name: ArcticCarbonObservatory
-Text Domain: ArcticCarbonObservatory
+Theme Name: Arctic Carbon Observatory Wordpress theme
+Text Domain: arcticcarbonobservatory-wp-theme
 Version: 0.001
-Description: Theme for FMI Arctic Carbon observatory
+Description: Wordpress child theme for FMI Arctic Carbon Observatory. Requires Observatory Wordpress parent theme
 Tags: arcticcarbonobservatory, FMI
-Author: Janne Nurmela
+Author: Janne Nurmela (FMI), Olli Niemitalo (HAMK)
 Author URI: https://google.com
-Template: fieldobservatory-wp-theme
+Template: observatory-wp-theme
 */


### PR DESCRIPTION
Updated to work together with new parent theme https://github.com/hamk-uas/observatory-wp-theme

The new parent theme should be cloned to the themes folder of the WordPress installation. After that the old parent theme fieldobservatory-wp-theme is no longer needed for Arctic Carbon Observatory. I will delete the janne branch of https://github.com/hamk-uas/fieldobservatory-wp-theme after this pull request is merged.